### PR TITLE
Ext4Pkg: Fixes to GDT checksum calculation

### DIFF
--- a/Features/Ext4Pkg/Ext4Dxe/BlockGroup.c
+++ b/Features/Ext4Pkg/Ext4Dxe/BlockGroup.c
@@ -169,20 +169,19 @@ Ext4CalculateBlockGroupDescChecksumGdtCsum (
   )
 {
   UINT16  Csum;
-  UINT16  Dummy;
 
-  Dummy = 0;
+  Csum = ~0;
 
-  Csum = CalculateCrc16Ansi (Partition->SuperBlock.s_uuid, 16, 0);
+  Csum = CalculateCrc16Ansi (Partition->SuperBlock.s_uuid, 16, Csum);
   Csum = CalculateCrc16Ansi (&BlockGroupNum, sizeof (BlockGroupNum), Csum);
   Csum = CalculateCrc16Ansi (BlockGroupDesc, OFFSET_OF (EXT4_BLOCK_GROUP_DESC, bg_checksum), Csum);
-  Csum = CalculateCrc16Ansi (&Dummy, sizeof (Dummy), Csum);
   Csum =
     CalculateCrc16Ansi (
       &BlockGroupDesc->bg_block_bitmap_hi,
       Partition->DescSize - OFFSET_OF (EXT4_BLOCK_GROUP_DESC, bg_block_bitmap_hi),
       Csum
       );
+
   return Csum;
 }
 


### PR DESCRIPTION
The GDT checksum was not calculated correctly.  This issue was previously masked by a typo in the EXT4_HAS_GDT_CSUM () macro.  Also, if EXT4_HAS_METADATA_CSUM () is TRUE, then the GDT checksum is not needed.

Fixes:
- Exclude bg_checksum.  The GDT checksum is calculated using crc16.  The ext4 docs state: "the bg_checksum field in bg_desc is skipped when calculating crc16 checksum".  Prior to this change, bg_checksum was zero'd and included. That's correct for the metadata calculation, but not for GDT. https://www.kernel.org/doc/html/latest/filesystems/ext4/globals.html
- The CalculateCrc16Ansi () function was returning the compliment of the checksum instead of the checksum.  This function has been fixed, but will now require ~0 as the initial seed instead of 0.

It should also be noted that if EXT4_IS_64_BIT() is FALSE, then the fields after bg_checksum should not be included in the checksum as they are 64-bit only fields. However, we can skip a conditional on EXT4_IS_64_BIT() because the CalculateCrc16Ansi () call in question will get a zero length.


Reviewed-by: Jeff Brasen <jbrasen@nvidia.com>
Reviewed-by: Jake Garver <jake@nvidia.com>
Tested-by: Jake Garver <jake@nvidia.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
